### PR TITLE
Fix/model memory issue

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,8 @@
 	"paths": {
 		"out": "out",
 		"raw": "raw",
-		"embeddings_file_name": "embeddings.pt"
+		"embeddings_file_name": "embeddings.pt",
+		"annoy_index_file_name": "annoy_index.ann"
 	},
 	"web": {
 		"debug": true,

--- a/config.json
+++ b/config.json
@@ -5,8 +5,7 @@
 	"paths": {
 		"out": "out",
 		"raw": "raw",
-		"embeddings_file_name": "embeddings.npy",
-		"image_file_paths": "paths.txt"
+		"embeddings_file_name": "embeddings.pt"
 	},
 	"web": {
 		"debug": true,

--- a/src/model.py
+++ b/src/model.py
@@ -8,89 +8,152 @@ import shot_detection
 from pathlib import Path
 from config import Config
 from annoy import AnnoyIndex #Checks for similarity of vectors
+from transformers import CLIPProcessor, CLIPModel
+import torch
+import clip
 
 class Model():
 	def __init__(self, config: Config):
 		self.config = config
 		self.out_folder = self.config.data['paths']['out']
 		self.embedding_path = os.path.join(self.out_folder, self.config.data['paths']['embeddings_file_name'])
-		self.filename_path = os.path.join(self.out_folder, self.config.data['paths']['image_file_paths'])
+		self.model, self.preprocess = clip.load("ViT-B/32", device = self.config.device)
 
 	def calculateEmbeddings(self):
-		
+		print("Calculating embeddings using device", self.config.device)
 		files = glob.glob(f'{self.out_folder}/*.jpg')
 		print('Found', len(files), 'shots!')
 
-		img_list = []
 		self.filename_list = []
+		embeddings = []
 
 		for file in files:
-			img = Image.open(file)
-			img_list.append(img.copy())
-			img.close()
-			filename = os.path.basename(file)
-			_file = Path(file)
-			filepath = _file.absolute()
-			self.filename_list.append(filename)
-		# len(img_list)
+			try:
+				filename = os.path.basename(file)
+				self.filename_list.append(filename)
+				img = self.preprocess(Image.open(file).convert("RGB")).unsqueeze(0).to(self.config.device)
 
-		with open(self.filename_path, "w") as f:
-			for path in self.filename_list:
-				f.write(str(path) + "\n")
+				with torch.no_grad():
+					embedding = self.model.encode_image(img)
+					embedding = embedding / embedding.norm(dim=-1, keepdim=True)  # normalize
+					embeddings.append(embedding.cpu())
 
-		self.model = SentenceTransformer('clip-ViT-B-32')
+			except Exception as err:
+				print("Err", err)
 
-		self.embeddings = self.model.encode(img_list, batch_size=32, convert_to_tensor=True)
-		# len(embeddings) #Amount of pictures
-		# embeddings.shape #Number of embeddings
 
-		print(len(self.embeddings), "shots found, filenames:", self.filename_list)
-		# data = {name: emb.tolist() for name, emb in zip(filename_list, self.embeddings)}
 
-		localEmbeddings = self.embeddings.cpu()
-		np.save(self.embedding_path, localEmbeddings)
+
+		# 	img_list.append(img.copy())
+		# 	img.close()
+		# 	filename = os.path.basename(file)
+		# 	_file = Path(file)
+		# 	filepath = _file.absolute()
+		# 	self.filename_list.append(filename)
+		# # len(img_list)
+
+		self.embeddings = torch.cat(embeddings, dim=0)
+		torch.save({
+			'embeddings': self.embeddings,
+			'filenames': self.filename_list
+		}, self.embedding_path)
+
+		# with open(self.filename_path, "w") as f:
+		# 	for path in self.filename_list:
+		# 		f.write(str(path) + "\n")
+
+
+		# model = CLIPModel.from_pretrained("openai/clip-vit-base-patch32").eval()
+		# processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
+
+		# model.to(self.config.device)
+
+		# embeddings = []
+
+		# for img in img_list:
+		# 	with torch.no_grad():
+		# 		img_embed = model.get_image_features()
+
+
+		# # old shit
+		# self.model = SentenceTransformer('clip-ViT-B-32')
+
+		# self.embeddings = self.model.encode(img_list, batch_size=32, normalize_embeddings=True)
+		# # len(embeddings) #Amount of pictures
+		# # embeddings.shape #Number of embeddings
+
+		# print(len(self.embeddings), "shots found, filenames:", self.filename_list)
+		# # data = {name: emb.tolist() for name, emb in zip(filename_list, self.embeddings)}
+
+		# localEmbeddings = self.embeddings.cpu()
+		# np.save(self.embedding_path, localEmbeddings)
 		# with open(self.embedding_path, "w") as f:
 		# 	json.dump(data, f, indent=2)
 
 	def loadSaved(self):
-		self.model = SentenceTransformer('clip-ViT-B-32')
-		# with open(self.embedding_path, "r") as f:
-		# 	embedding_data = json.load(f)
-		# self.embeddings = {k: np.array(v) for k, v in embedding_data.items()}
-		localEmbeddings = np.load(self.embedding_path)
-		self.embeddings = localEmbeddings
 
-		with open(self.filename_path, "r") as f:
-			self.filename_list = [line.strip() for line in f.readlines()]
+		data = torch.load(self.embedding_path)
+		self.embeddings = data['embeddings']
+		self.filename_list = data['filenames']
+		# # with open(self.embedding_path, "r") as f:
+		# # 	embedding_data = json.load(f)
+		# # self.embeddings = {k: np.array(v) for k, v in embedding_data.items()}
+		# localEmbeddings = np.load(self.embedding_path)
+		# self.embeddings = localEmbeddings
+
+		# with open(self.filename_path, "r") as f:
+		# 	self.filename_list = [line.strip() for line in f.readlines()]
 
 	def estimate(self, query):
-	# doing model stuff
-
-		annoy_index = AnnoyIndex(512, metric="angular" ) #Dimension and metric to compute distance
-		#Could also use cosine and more
-		print(query)
-
+		annoy_index = AnnoyIndex(512, metric='angular')
 		for idx, embedding in enumerate(self.embeddings):
-			annoy_index.add_item(idx, embedding) #Number of the index, actual embeddings
-			
-		annoy_index.build(200)#Number of branches in your index 10, up to 100 200, the higher the more accurate, but will be a larger file
+			annoy_index.add_item(idx, embedding)
+		annoy_index.build(200)
 
-		query_text = self.model.encode([query])
-		print(f"Query shape: {query_text.shape}") #Text query encoded
+		result = []
+		with torch.no_grad():
+			print("Query:", query)
+			text = clip.tokenize([query]).to(self.config.device)
+			features = self.model.encode_text(text)
+			print(f"Query shape: {features.shape}")
+			result = annoy_index.get_nns_by_vector(features[0], 50)
+			print(f"Most likely frames: {result}")
 
-		result = annoy_index.get_nns_by_vector(query_text[0], 50) #nns = nearest neighbour. So five nearest neighbours
-		print(f"Most likely frames: {result}") #Image ID of most likely frame
-
-		# lookup paths and return them (image url, video url, frame)
 		paths = []
 		for res in result:
 			filename = self.filename_list[res]
 			videofile, frame = shot_detection.videoFileFromImage(filename)
 			paths.append((filename, videofile, frame))
 
-		# paths = [self.filename_list[i] for i in result]
-
-		# for item in result:
-		# 	#print(item, print(files[item]))
-		# 	display(img_list[item])
 		return paths
+
+	# doing model stuff
+
+		# annoy_index = AnnoyIndex(512, metric="angular" ) #Dimension and metric to compute distance
+		# #Could also use cosine and more
+		# print(query)
+
+		# for idx, embedding in enumerate(self.embeddings):
+		# 	annoy_index.add_item(idx, embedding) #Number of the index, actual embeddings
+			
+		# annoy_index.build(200)#Number of branches in your index 10, up to 100 200, the higher the more accurate, but will be a larger file
+
+		# query_text = self.model.encode([query])
+		# print(f"Query shape: {query_text.shape}") #Text query encoded
+
+		# result = annoy_index.get_nns_by_vector(query_text[0], 50) #nns = nearest neighbour. So five nearest neighbours
+		# print(f"Most likely frames: {result}") #Image ID of most likely frame
+
+		# # lookup paths and return them (image url, video url, frame)
+		# paths = []
+		# for res in result:
+		# 	filename = self.filename_list[res]
+		# 	videofile, frame = shot_detection.videoFileFromImage(filename)
+		# 	paths.append((filename, videofile, frame))
+
+		# # paths = [self.filename_list[i] for i in result]
+
+		# # for item in result:
+		# # 	#print(item, print(files[item]))
+		# # 	display(img_list[item])
+		# return paths

--- a/src/model.py
+++ b/src/model.py
@@ -4,6 +4,7 @@ import glob
 import os
 import numpy as np
 import json
+import time
 import shot_detection
 from pathlib import Path
 from config import Config
@@ -17,13 +18,17 @@ class Model():
 		self.config = config
 		self.out_folder = self.config.data['paths']['out']
 		self.embedding_path = os.path.join(self.out_folder, self.config.data['paths']['embeddings_file_name'])
+		self.annoy_index_path = os.path.join(self.out_folder, self.config.data['paths']['annoy_index_file_name'])
 		self.model, self.preprocess = clip.load("ViT-B/32", device = self.config.device)
 
 	def calculateEmbeddings(self):
-		print("Calculating embeddings using device", self.config.device)
+		start_time = time.time()
+		print(round(time.time()-start_time,3), "Calculating embeddings using device", self.config.device)
 		files = glob.glob(f'{self.out_folder}/*.jpg')
-		print('Found', len(files), 'shots!')
+		print(round(time.time()-start_time,3), 'Found', len(files), 'shots!')
 
+
+		print(round(time.time()-start_time,3), "Generating embeddings...")
 		self.filename_list = []
 		embeddings = []
 
@@ -40,17 +45,8 @@ class Model():
 
 			except Exception as err:
 				print("Err", err)
-
-
-
-
-		# 	img_list.append(img.copy())
-		# 	img.close()
-		# 	filename = os.path.basename(file)
-		# 	_file = Path(file)
-		# 	filepath = _file.absolute()
-		# 	self.filename_list.append(filename)
-		# # len(img_list)
+				return
+		print(round(time.time()-start_time,3), "Saving embeddings...")
 
 		self.embeddings = torch.cat(embeddings, dim=0)
 		torch.save({
@@ -58,57 +54,36 @@ class Model():
 			'filenames': self.filename_list
 		}, self.embedding_path)
 
-		# with open(self.filename_path, "w") as f:
-		# 	for path in self.filename_list:
-		# 		f.write(str(path) + "\n")
+		print(round(time.time()-start_time,3), "Building annoy index...")
+		self.annoy_index = AnnoyIndex(512, metric='angular')
 
+		for idx, embedding in enumerate(self.embeddings):
+			self.annoy_index.add_item(idx, embedding)
+		self.annoy_index.build(200)
 
-		# model = CLIPModel.from_pretrained("openai/clip-vit-base-patch32").eval()
-		# processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
+		self.annoy_index.save(self.annoy_index_path)
 
-		# model.to(self.config.device)
-
-		# embeddings = []
-
-		# for img in img_list:
-		# 	with torch.no_grad():
-		# 		img_embed = model.get_image_features()
-
-
-		# # old shit
-		# self.model = SentenceTransformer('clip-ViT-B-32')
-
-		# self.embeddings = self.model.encode(img_list, batch_size=32, normalize_embeddings=True)
-		# # len(embeddings) #Amount of pictures
-		# # embeddings.shape #Number of embeddings
-
-		# print(len(self.embeddings), "shots found, filenames:", self.filename_list)
-		# # data = {name: emb.tolist() for name, emb in zip(filename_list, self.embeddings)}
-
-		# localEmbeddings = self.embeddings.cpu()
-		# np.save(self.embedding_path, localEmbeddings)
-		# with open(self.embedding_path, "w") as f:
-		# 	json.dump(data, f, indent=2)
+		print(round(time.time()-start_time,3), "Done calculating embeddings!")
 
 	def loadSaved(self):
 
+		print("Loading saved model...")
 		data = torch.load(self.embedding_path)
 		self.embeddings = data['embeddings']
 		self.filename_list = data['filenames']
-		# # with open(self.embedding_path, "r") as f:
-		# # 	embedding_data = json.load(f)
-		# # self.embeddings = {k: np.array(v) for k, v in embedding_data.items()}
-		# localEmbeddings = np.load(self.embedding_path)
-		# self.embeddings = localEmbeddings
 
-		# with open(self.filename_path, "r") as f:
-		# 	self.filename_list = [line.strip() for line in f.readlines()]
+		print("Loading annoy index...")
+		self.annoy_index = AnnoyIndex(512, metric='angular')
+		self.annoy_index.load(self.annoy_index_path)
+
+		print("Loaded successfully!")
 
 	def estimate(self, query):
-		annoy_index = AnnoyIndex(512, metric='angular')
-		for idx, embedding in enumerate(self.embeddings):
-			annoy_index.add_item(idx, embedding)
-		annoy_index.build(200)
+		start_time = time.time()
+		print(round(time.time()-start_time,3), "Estimating query", query)
+		
+
+		print(round(time.time()-start_time,3), "Annoy Index built")
 
 		result = []
 		with torch.no_grad():
@@ -116,8 +91,8 @@ class Model():
 			text = clip.tokenize([query]).to(self.config.device)
 			features = self.model.encode_text(text)
 			print(f"Query shape: {features.shape}")
-			result = annoy_index.get_nns_by_vector(features[0], 50)
-			print(f"Most likely frames: {result}")
+			result = self.annoy_index.get_nns_by_vector(features[0], 50)
+			print(round(time.time()-start_time,3), f"Most likely frames: {result}")
 
 		paths = []
 		for res in result:
@@ -125,35 +100,5 @@ class Model():
 			videofile, frame = shot_detection.videoFileFromImage(filename)
 			paths.append((filename, videofile, frame))
 
+		print(round(time.time()-start_time,3), "done, returning...")
 		return paths
-
-	# doing model stuff
-
-		# annoy_index = AnnoyIndex(512, metric="angular" ) #Dimension and metric to compute distance
-		# #Could also use cosine and more
-		# print(query)
-
-		# for idx, embedding in enumerate(self.embeddings):
-		# 	annoy_index.add_item(idx, embedding) #Number of the index, actual embeddings
-			
-		# annoy_index.build(200)#Number of branches in your index 10, up to 100 200, the higher the more accurate, but will be a larger file
-
-		# query_text = self.model.encode([query])
-		# print(f"Query shape: {query_text.shape}") #Text query encoded
-
-		# result = annoy_index.get_nns_by_vector(query_text[0], 50) #nns = nearest neighbour. So five nearest neighbours
-		# print(f"Most likely frames: {result}") #Image ID of most likely frame
-
-		# # lookup paths and return them (image url, video url, frame)
-		# paths = []
-		# for res in result:
-		# 	filename = self.filename_list[res]
-		# 	videofile, frame = shot_detection.videoFileFromImage(filename)
-		# 	paths.append((filename, videofile, frame))
-
-		# # paths = [self.filename_list[i] for i in result]
-
-		# # for item in result:
-		# # 	#print(item, print(files[item]))
-		# # 	display(img_list[item])
-		# return paths

--- a/src/shot_detection.py
+++ b/src/shot_detection.py
@@ -22,7 +22,6 @@ def shotDetection(path, config: Config):
 	hists = []
 	BINS = 64
 	ranges=[0, 256]
-	SAMPLING_INT = 250
 	frameCount = -1
 	frameIntervals = []
 	frames = []


### PR DESCRIPTION
Fixed the model taking around 80GiB of RAM (which my system doesn't have). Saving and loading the model takes slightly longer, and calculating the annoy index took around 40s **per request**. Now it's generated once after the embeddings during the calculation period, to allow fast responses during runtime and a halfway okay-ish load time.